### PR TITLE
Camel 3.22.2 with fixed integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <camel.version>3.20.0</camel.version>
+        <camel.version>3.22.2</camel.version>
         <spring.boot-version>2.7.18</spring.boot-version>
         <hawtio.spring.boot-version>2.10.2</hawtio.spring.boot-version>
         <lombok.version>1.18.34</lombok.version>

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/CollectQueueUpdateIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/CollectQueueUpdateIT.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 import se.skltp.ei.util.EngagementTestUtil.DomainType;
 import se.skltp.ei.util.NotificationAssert;
 import se.skltp.ei.util.UpdateRequestUtil;
@@ -22,7 +23,7 @@ import se.skltp.ei.util.UpdateRequestUtil;
 // and that the collect queue is collected and sent for processing.
 // The business logic in aggregation should be tested more in unit test
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 public class CollectQueueUpdateIT {
 

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/FindContentIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/FindContentIT.java
@@ -29,12 +29,13 @@ import riv.itintegration.engagementindex.findcontent._1.rivtabp21.FindContentRes
 import riv.itintegration.engagementindex.findcontentresponder._1.FindContentResponseType;
 import riv.itintegration.engagementindex.findcontentresponder._1.FindContentType;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 import se.skltp.ei.entity.repository.EngagementRepository;
 import se.skltp.ei.util.EngagementTestUtil;
 import se.skltp.ei.util.EngagementTestUtil.DomainType;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 //@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class FindContentIT {

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/GetBackendStatusIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/GetBackendStatusIT.java
@@ -12,9 +12,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 //@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class GetBackendStatusIT {

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/GetSubscriberStatusIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/GetSubscriberStatusIT.java
@@ -10,9 +10,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 //@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class GetSubscriberStatusIT {

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ProcessQueueNotificationUpdateIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ProcessQueueNotificationUpdateIT.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import riv.itintegration.engagementindex._1.EngagementTransactionType;
 import riv.itintegration.engagementindex.processnotificationresponder._1.ProcessNotificationType;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 import se.skltp.ei.entity.model.Engagement;
 import se.skltp.ei.entity.repository.EngagementRepository;
 import se.skltp.ei.util.DatabaseAssert;
@@ -34,7 +35,7 @@ import se.skltp.ei.util.NotificationAssert;
 import se.skltp.ei.util.ProcessNotificationRequestUtil;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 public class ProcessQueueNotificationUpdateIT {
 

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ProcessQueueUpdateIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ProcessQueueUpdateIT.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import riv.itintegration.engagementindex._1.EngagementTransactionType;
 import riv.itintegration.engagementindex.updateresponder._1.UpdateType;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 import se.skltp.ei.entity.model.Engagement;
 import se.skltp.ei.entity.repository.EngagementRepository;
 import se.skltp.ei.util.DatabaseAssert;
@@ -33,7 +34,7 @@ import se.skltp.ei.util.NotificationAssert;
 import se.skltp.ei.util.UpdateRequestUtil;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 public class ProcessQueueUpdateIT {
 

--- a/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ResetSubscriberCacheIT.java
+++ b/skltp-ei-backend/src/test/java/se/skltp/ei/integrationtests/ResetSubscriberCacheIT.java
@@ -9,12 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import se.skltp.ei.EiBackendApplication;
+import se.skltp.ei.EiTeststubRoute;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static se.skltp.ei.EiTeststubRoute.LOGICALADDREESS_MOCK;
 
 @CamelSpringBootTest
-@SpringBootTest(classes = {EiBackendApplication.class})
+@SpringBootTest(classes = {EiBackendApplication.class, EiTeststubRoute.class})
 @ActiveProfiles("teststub")
 public class ResetSubscriberCacheIT {
   @Produce


### PR DESCRIPTION
Behövde peka ut klassen där teststub-routen definieras för att den skulle laddas